### PR TITLE
Add locking

### DIFF
--- a/clilog.go
+++ b/clilog.go
@@ -43,7 +43,6 @@ var globalLogger = logger{
 	level:     LevelInfo,
 	formatter: mustNewFormatter(DefaultFormat),
 	out:       os.Stderr,
-	outMu:     sync.Mutex{},
 }
 
 func (l *logger) logf(level Level, msg string) {

--- a/clilog.go
+++ b/clilog.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 )
 
 // So we can override in tests
 var (
-	now              = time.Now
-	output io.Writer = os.Stderr
+	now = time.Now
 )
 
 type Level int
@@ -34,15 +34,19 @@ const (
 type logger struct {
 	level     Level
 	formatter formatter
+	out       io.Writer
+	outMu     sync.Mutex
 }
 
 // Specific "logger" we use in all the public logging functions
 var globalLogger = logger{
 	level:     LevelInfo,
 	formatter: mustNewFormatter(DefaultFormat),
+	out:       os.Stderr,
+	outMu:     sync.Mutex{},
 }
 
-func (l logger) logf(level Level, msg string) {
+func (l *logger) logf(level Level, msg string) {
 	if level < l.level {
 		return
 	}
@@ -52,7 +56,9 @@ func (l logger) logf(level Level, msg string) {
 		Time:    now(),
 		Message: msg,
 	}
-	fmt.Fprintln(output, l.formatter.format(data))
+	l.outMu.Lock()
+	defer l.outMu.Unlock()
+	fmt.Fprintln(l.out, l.formatter.format(data))
 }
 
 // --- Configuration ---

--- a/clilog_test.go
+++ b/clilog_test.go
@@ -12,9 +12,7 @@ func TestLogf(t *testing.T) {
 
 	// Restore after tests
 	originalNow := now
-	originalOutput := output
 	defer func() { now = originalNow }()
-	defer func() { output = originalOutput }()
 
 	now = func() time.Time {
 		return time.Date(2025, time.January, 1, 0, 0, 0, 0, time.Local)
@@ -51,10 +49,10 @@ func TestLogf(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
 			var buf bytes.Buffer
-			output = &buf
 			var exampleLogger = logger{
 				level:     tc.currentLevel,
 				formatter: mustNewFormatter(DefaultFormatNoColor),
+				out:       &buf,
 			}
 			exampleLogger.logf(tc.messageLevel, tc.message)
 			logWritten := buf.String()


### PR DESCRIPTION
## What

Adding locking around writing to log

## Why

There's a possibility of two goroutines logging at the same time and interleaving entries.

It's mostly a theoretic issue because of the way os.Stderr is buffered, but might as well implement it for robustness/correctness.